### PR TITLE
Semantically correct highlighting for functions, records, etc. referenced as atoms

### DIFF
--- a/Syntaxes/Erlang.plist
+++ b/Syntaxes/Erlang.plist
@@ -25,10 +25,6 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#behaviour-directive</string>
-		</dict>
-		<dict>
-			<key>include</key>
 			<string>#record-directive</string>
 		</dict>
 		<dict>
@@ -117,46 +113,6 @@
 					<string>constant.other.symbol.unquoted.erlang</string>
 				</dict>
 			</array>
-		</dict>
-		<key>behaviour-directive</key>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.directive.begin.erlang</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.directive.behaviour.erlang</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.parameters.begin.erlang</string>
-				</dict>
-				<key>4</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.type.class.module.definition.erlang</string>
-				</dict>
-				<key>5</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.parameters.end.erlang</string>
-				</dict>
-				<key>6</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.directive.end.erlang</string>
-				</dict>
-			</dict>
-			<key>match</key>
-			<string>^\s*+(-)\s*+(behaviour)\s*+(\()\s*+([a-z][a-zA-Z\d@_]*+)\s*+(\))\s*+(\.)</string>
-			<key>name</key>
-			<string>meta.directive.module.erlang</string>
 		</dict>
 		<key>binary</key>
 		<dict>
@@ -1482,7 +1438,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(integer|float|binary|bytes|bitstring|bits)|(signed|unsigned)|(big|little|native)|(unit)|(-)</string>
+					<string>(integer|float|binary)|(signed|unsigned)|(big|little|native)|(unit)|(-)</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
When function or record names contain characters other than [a-zA-Z0-9@_], it necessary to enclose them in quotes, exactly like it is with atoms. Github does it the right way, it matches the name as a function(-call):

``` erlang
'foo.bar'(Param, some_atom) ->
  'foo.baz'(Param, some_atom);
```

However, currently everything that is enclosed in single quotes is matched as an atom. This leads to confusion when function names are highlighted as atoms, like it is sometimes necessary, especially for generated code. Therefore I propose a fix that introduces the following tweaks:
- Highlight quoted function definitions correctly
- Highlight quoted function calls correctly
- Highlight quoted function references (e.g. `'foo.bar'/2`) correctly
- Highlight quoted record definitions (names and types) correctly
- Highlight quoted record invocations (names and types) correctly
- Introduce behaviour directive, as it is the same context as module, import and export

Here's an example:

![Example](https://f.cloud.github.com/assets/932156/62849/756064a2-5d87-11e2-8c77-09567648394c.png)

I hope that this finds its way into the master, as it takes a lot of pain away from the eyes.

I've got a second fix coming up for the type system, but I will place a second pull request, in case this fix isn't accepted.

Best,
Martin
