### PR TITLE
Correct highlighting for types/specs

### DIFF
--- a/Syntaxes/Erlang.plist
+++ b/Syntaxes/Erlang.plist
@@ -424,7 +424,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>^\s*+(-)\s*+([a-z][a-zA-Z\d@_]*+)\s*+(\()</string>
+					<string>^\s*+(-)\s*+([a-z][a-zA-Z\d@_]*+)\s*+(\(?)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -444,7 +444,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\))\s*+(\.)</string>
+					<string>(\)?)\s*+(\.)</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1332,7 +1332,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(([a-z][a-zA-Z\d@_]*+)|(_))\s*+(=)</string>
+					<string>(([a-z][a-zA-Z\d@_]*+)|(_))\s*+(=|::)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -2501,7 +2501,7 @@
 		<key>symbolic-operator</key>
 		<dict>
 			<key>match</key>
-			<string>\+\+|\+|--|-|\*|/=|/|=/=|=:=|==|=&lt;|=|&lt;-|&lt;|&gt;=|&gt;|!</string>
+			<string>\+\+|\+|--|-|\*|/=|/|=/=|=:=|==|=&lt;|=|&lt;-|&lt;|&gt;=|&gt;|!|::</string>
 			<key>name</key>
 			<string>keyword.operator.symbolic.erlang</string>
 		</dict>


### PR DESCRIPTION
My second pull request fixes two bugs associated with Erlang's type system:
1. The parentheses after some directives, e.g. the `-spec` directive can be omitted, however the directive would then be highlighted as an atom.

``` erlang
-spec(foo() -> { ok, bar }). % spec ix highlighted
-spec foo() -> { ok, bar }. % spec is not highlighted, though it is perfectly valid
```
1. Defining record types, the `::` operator was not recognized, and types were only recognized, if defaults were set:

``` erlang
-record({
  foo = default :: atom() % atom() is highlighted as a function/type
  bar :: atom() % atom() is not highlighted
})
```

Best,
Martin
