### PR TITLE
Added missing types for bit-level pattern matching

### DIFF
--- a/Syntaxes/Erlang.plist
+++ b/Syntaxes/Erlang.plist
@@ -1438,7 +1438,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(integer|float|binary)|(signed|unsigned)|(big|little|native)|(unit)|(-)</string>
+					<string>(integer|float|binary|bytes|bitstring|bits)|(signed|unsigned)|(big|little|native)|(unit)|(-)</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Added missing type `bitstring` + abbrevation `bits`, as well as the abbrevation for `binary` which is `bytes`.

Source: http://www.erlang.org/doc/programming_examples/bit_syntax.html
