### PR TITLE
Added behaviour directive

### DIFF
--- a/Syntaxes/Erlang.plist
+++ b/Syntaxes/Erlang.plist
@@ -25,6 +25,10 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#behaviour-directive</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#record-directive</string>
 		</dict>
 		<dict>
@@ -113,6 +117,46 @@
 					<string>constant.other.symbol.unquoted.erlang</string>
 				</dict>
 			</array>
+		</dict>
+		<key>behaviour-directive</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.directive.begin.erlang</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.directive.behaviour.erlang</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.begin.erlang</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.type.class.behaviour.definition.erlang</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.end.erlang</string>
+				</dict>
+				<key>6</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.directive.end.erlang</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>^\s*+(-)\s*+(behaviour)\s*+(\()\s*+([a-z][a-zA-Z\d@_]*+)\s*+(\))\s*+(\.)</string>
+			<key>name</key>
+			<string>meta.directive.behaviour.erlang</string>
 		</dict>
 		<key>binary</key>
 		<dict>


### PR DESCRIPTION
The `behaviour` directive is part of the standard OTP distribution. However, the syntax highlighting was not elegant, as the contents where highlighted as atoms:

``` erlang
-behaviour(foo_bar). % foo_bar highlighted as an atom
```

With this fix, the `behaviour` directive is highlighted exactly like the `module` directive, since it is within a similar context.

Source: http://www.erlang.org/doc/design_principles/des_princ.html#id59741
