### PR TITLE
Fix float exponent highlighting

### DIFF
--- a/Syntaxes/Erlang.plist
+++ b/Syntaxes/Erlang.plist
@@ -1730,14 +1730,14 @@
 							<key>name</key>
 							<string>punctuation.separator.integer-float.erlang</string>
 						</dict>
-						<key>3</key>
+						<key>2</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.separator.float-exponent.erlang</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\d++(\.)\d++(([eE][\+\-])?\d++)?</string>
+					<string>\d++(\.)\d++([eE][\+\-]?\d++)?</string>
 					<key>name</key>
 					<string>constant.numeric.float.erlang</string>
 				</dict>


### PR DESCRIPTION
Note: corrected the merge-error. Sorry for the inconvenience!

``` erlang
1.0e+10 % highlights correctly
1.0e-10 % highlights correctly
1.0e10  % doesn't highlight correctly, though valid
```

See http://www.erlang.org/doc/reference_manual/data_types.html#id68697
