### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/Syntaxes/Erlang.plist
+++ b/Syntaxes/Erlang.plist
@@ -1947,7 +1947,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>16(#)\h++</string>
+					<string>16(#)[0-9A-Fa-f]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.hexadecimal.erlang</string>
 				</dict>


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.