### PR TITLE
Remove query as a keyword

### DIFF
--- a/Preferences/Indentation Rules.tmPreferences
+++ b/Preferences/Indentation Rules.tmPreferences
@@ -13,7 +13,7 @@
 		<key>disableIndentCorrections</key>
 		<true/>
 		<key>increaseIndentPattern</key>
-		<string>^[^%]*(\b(if|case|receive|after|fun|try|catch|begin|query)\b(?!.*\b(end)\b.*))|(-&gt;(\s*%.*)?$)</string>
+		<string>^[^%]*(\b(if|case|receive|after|fun|try|catch|begin)\b(?!.*\b(end)\b.*))|(-&gt;(\s*%.*)?$)</string>
 		<key>indentOnPaste</key>
 		<string>simple</string>
 	</dict>

--- a/Syntaxes/Erlang.plist
+++ b/Syntaxes/Erlang.plist
@@ -875,37 +875,6 @@
 						</dict>
 					</array>
 				</dict>
-				<dict>
-					<key>begin</key>
-					<string>\b(query)\b</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.control.query.erlang</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>\b(end)\b</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.control.end.erlang</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>meta.expression.query.erlang</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#everything-else</string>
-						</dict>
-					</array>
-				</dict>
 			</array>
 		</dict>
 		<key>function</key>
@@ -1489,7 +1458,7 @@
 		<key>keyword</key>
 		<dict>
 			<key>match</key>
-			<string>\b(after|begin|case|catch|cond|end|fun|if|let|of|query|try|receive|when)\b</string>
+			<string>\b(after|begin|case|catch|cond|end|fun|if|let|of|try|receive|when)\b</string>
 			<key>name</key>
 			<string>keyword.control.erlang</string>
 		</dict>


### PR DESCRIPTION
`query` was not a keyword since 2012, in OTP 21 it was completely
removed and became a regular atom. This reflects this change.

Ref: https://github.com/erlang/otp/commit/fbed0ac73b65010953db2a2b87c472b191c1382e