### PR TITLE
Fix `~"` syntax

### DIFF
--- a/Syntaxes/Erlang.plist
+++ b/Syntaxes/Erlang.plist
@@ -2505,7 +2505,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>~.?</string>
+					<string>~[^"]?</string>
 					<key>name</key>
 					<string>invalid.illegal.string.erlang</string>
 				</dict>


### PR DESCRIPTION
If a string ends with a `~"` we cannot know if it is a valid control character or not, so we should not show it as an error.

This fixes #19 and https://github.com/erlang-ls/erlang_ls/issues/730